### PR TITLE
wip: add update fns for TraceGraph updating

### DIFF
--- a/src/model/dynamic_list.rs
+++ b/src/model/dynamic_list.rs
@@ -31,7 +31,7 @@ impl<T: Clone + PartialEq> DynamicList<T> {
     }
 
     /// Returns a reference to the items as a slice.
-    pub fn items(&self) -> &[T] {
+    pub fn _items(&self) -> &[T] {
         &self.items
     }
 

--- a/src/model/otel_view.rs
+++ b/src/model/otel_view.rs
@@ -5,6 +5,7 @@ use crate::{
 use arc_swap::ArcSwap;
 use opentelemetry_proto::tonic::trace::v1::Span;
 use std::{cmp::Reverse, sync::Arc};
+use tracing::debug;
 
 /// Manages the rendering state for the OTEL tab of the TUI.
 ///
@@ -64,6 +65,7 @@ impl OtelViewState {
         if !has_changed {
             return false;
         }
+        debug!("TraceGraph changes found, updating");
 
         // Get the latest trace ids, sort them by start, and set them in the trace list
         // for display

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     states::Action,
     update::{
         focus::FocusUpdate, layout::LayoutUpdate, scroll::ScrollUpdate, search::SearchUpdate,
+        select_span::SelectSpanUpdate, tick::TickUpdate, trace_graph::TraceGraphUpdate,
         window::WindowSizeUpdate,
     },
 };
@@ -11,6 +12,9 @@ pub mod focus;
 pub mod layout;
 pub mod scroll;
 pub mod search;
+pub mod select_span;
+pub mod tick;
+pub mod trace_graph;
 pub mod window;
 
 pub type UpdateList = Vec<&'static dyn Update>;
@@ -24,4 +28,7 @@ pub static UPDATE_DEFS: &[&dyn Update] = &[
     &WindowSizeUpdate,
     &SearchUpdate,
     &LayoutUpdate,
+    &TickUpdate,
+    &TraceGraphUpdate,
+    &SelectSpanUpdate,
 ];

--- a/src/update/scroll.rs
+++ b/src/update/scroll.rs
@@ -1,6 +1,9 @@
 use crate::{
     app_state::AppState,
-    model::{cursor::Cursor, ledger_view::LedgerViewState, window::WindowState},
+    model::{
+        cursor::Cursor, ledger_view::LedgerViewState, otel_view::OtelViewState, window::WindowState,
+    },
+    otel::{SpanId, graph::TraceGraph, span_ext::SpanExt},
     states::{Action, InspectOption, LedgerBrowse, LedgerMode, WidgetSlot},
     update::Update,
 };
@@ -57,22 +60,51 @@ impl Update for ScrollUpdate {
             WidgetSlot::InspectOption => s.inspect_option.scroll(direction),
             WidgetSlot::LedgerMode => {
                 s.ledger_mode.scroll(direction);
-                // This widget triggers a layout update on scroll.
+                // This widget triggers a layout update on scroll to add or remove the
+                // search bar
                 return vec![Action::UpdateLayout(s.frame_area)];
             }
-            WidgetSlot::LedgerOptions | WidgetSlot::List => {
+            WidgetSlot::LedgerOptions => {
                 let mode = s.ledger_mode.current();
-                match s.inspect_option.current() {
-                    InspectOption::Ledger => {
-                        scroll_ledger_view(&mut s.ledger_view, direction, mode, s.slot_focus)
-                    }
-                    InspectOption::Otel => {}
-                    InspectOption::Chain => {}
+                match mode {
+                    LedgerMode::Browse => s.ledger_view.browse_options.scroll(direction),
+                    LedgerMode::Search => s.ledger_view.search_options.scroll(direction),
                 }
             }
+            WidgetSlot::List => match s.inspect_option.current() {
+                InspectOption::Ledger => {
+                    let mode = s.ledger_mode.current();
+                    scroll_ledger_list(&mut s.ledger_view, direction, mode);
+                }
+                InspectOption::Otel => {
+                    // TODO: Make this logic simpler by taking advantage of the
+                    // DynamicList struct
+
+                    // First scroll the trace list itself
+                    s.otel_view.trace_list.scroll(direction);
+                    let graph = s.otel_view.trace_graph_source.load();
+
+                    // Then find the new focused span--it's the first span (root) in the
+                    // new trace
+                    let new_focused_span = s
+                        .otel_view
+                        .trace_list
+                        .selection()
+                        .and_then(|trace_id| graph.traces.get(trace_id))
+                        .and_then(|trace_meta| trace_meta.roots().first_key_value())
+                        .and_then(|(_, root_ids)| root_ids.first())
+                        .and_then(|root_id| graph.spans.get(root_id))
+                        .cloned();
+
+                    s.otel_view.focused_span = new_focused_span;
+                    // If we've scrolled to a new Trace, the selected span is reset
+                    s.otel_view.selected_span = None;
+                }
+                InspectOption::Chain => { /* There's no list widget in the Chain tab */ }
+            },
             WidgetSlot::Details => match s.inspect_option.current() {
-                InspectOption::Otel => {}
-                InspectOption::Ledger => { /* TODO: Impl item details scroll. */ }
+                InspectOption::Otel => scroll_trace_details(&mut s.otel_view, direction),
+                InspectOption::Ledger => { /* TODO: Impl item details scroll */ }
                 InspectOption::Chain => {}
             },
             _ => trace!("No scroll logic for slot {:?}", s.slot_focus),
@@ -81,43 +113,89 @@ impl Update for ScrollUpdate {
     }
 }
 
-/// Determines which list in the ledger view to scroll and scrolls it.
-fn scroll_ledger_view(
+/// Scrolls the list within the ledger view.
+fn scroll_ledger_list(
     ledger_view: &mut LedgerViewState,
     direction: ScrollDirection,
     mode: &LedgerMode,
-    focused_slot: WidgetSlot,
 ) {
-    if let Some(list) = get_scrollable_ledger_list(ledger_view, mode, focused_slot) {
+    if let Some(list) = get_ledger_list(ledger_view, mode) {
         list.scroll(direction);
     }
 }
 
-/// Helper to get a mutable reference to the currently active scrollable list in the ledger.
-fn get_scrollable_ledger_list<'a>(
+/// Helper to get a mutable reference to the currently active list in ledger view for
+/// scrolling.
+fn get_ledger_list<'a>(
     ledger_view: &'a mut LedgerViewState,
-    mode: &LedgerMode,
-    focused_slot: WidgetSlot,
+    mode: &'a LedgerMode,
 ) -> Option<&'a mut dyn ScrollableList> {
-    match focused_slot {
-        WidgetSlot::LedgerOptions => match mode {
-            LedgerMode::Browse => Some(&mut ledger_view.browse_options),
-            LedgerMode::Search => Some(&mut ledger_view.search_options),
+    match mode {
+        LedgerMode::Browse => match ledger_view.browse_options.selected()? {
+            LedgerBrowse::Accounts => Some(&mut ledger_view.accounts),
+            LedgerBrowse::BlockIssuers => Some(&mut ledger_view.block_issuers),
+            LedgerBrowse::DReps => Some(&mut ledger_view.dreps),
+            LedgerBrowse::Pools => Some(&mut ledger_view.pools),
+            LedgerBrowse::Proposals => Some(&mut ledger_view.proposals),
+            LedgerBrowse::Utxos => Some(&mut ledger_view.utxos),
         },
-        WidgetSlot::List => match mode {
-            LedgerMode::Browse => match ledger_view.browse_options.selected()? {
-                LedgerBrowse::Accounts => Some(&mut ledger_view.accounts),
-                LedgerBrowse::BlockIssuers => Some(&mut ledger_view.block_issuers),
-                LedgerBrowse::DReps => Some(&mut ledger_view.dreps),
-                LedgerBrowse::Pools => Some(&mut ledger_view.pools),
-                LedgerBrowse::Proposals => Some(&mut ledger_view.proposals),
-                LedgerBrowse::Utxos => Some(&mut ledger_view.utxos),
-            },
-            LedgerMode::Search => ledger_view
-                .utxos_by_addr_search
-                .get_current_res_mut()
-                .map(|r| r as &mut dyn ScrollableList),
-        },
-        _ => None,
+        LedgerMode::Search => ledger_view
+            .utxos_by_addr_search
+            .get_current_res_mut()
+            .map(|r| r as &mut dyn ScrollableList),
+    }
+}
+
+/// Scrolls to the next focused span within the OTEL trace details view.
+fn scroll_trace_details(otel_view: &mut OtelViewState, direction: ScrollDirection) {
+    let data = otel_view.trace_graph_source.load();
+    let Some(ordered_spans) = get_ordered_spans_for_view(&data, otel_view) else {
+        return;
+    };
+    if ordered_spans.is_empty() {
+        return;
+    }
+
+    // Find the index of the currently focused span in the span list
+    let current_index = otel_view
+        .focused_span
+        .as_ref()
+        .and_then(|span| ordered_spans.iter().position(|id| *id == span.span_id()));
+
+    let len = ordered_spans.len();
+
+    let new_index = match direction {
+        // Allow wrapping
+        ScrollDirection::Down => current_index.map_or(0, |i| (i + 1) % len),
+        ScrollDirection::Up => current_index.map_or(len - 1, |i| (i + len - 1) % len),
+    };
+
+    if Some(new_index) != current_index {
+        // Update the focused span given the new index
+        otel_view.focused_span = ordered_spans
+            .get(new_index)
+            .and_then(|id| data.spans.get(id).cloned());
+    }
+}
+
+/// Helper to get the list of spans for scrolling. If a span is selected, we only get
+/// that span's subtree. If a span isn't selected, we get all the spans for the selected
+/// trace.
+fn get_ordered_spans_for_view(data: &TraceGraph, otel_view: &OtelViewState) -> Option<Vec<SpanId>> {
+    // Determine if a span is selected
+    if let Some(selected_span) = &otel_view.selected_span {
+        let selected_span_id = selected_span.span_id();
+        // Get the span's ancestors. The iter starts at the span's parent and walks *up*
+        // the tree--we reverse this so that the resulting list is in ascending order.
+        let mut ancestors: Vec<SpanId> = data.ancestor_iter(selected_span_id).collect();
+        ancestors.reverse();
+        let self_and_descendants = data.descendent_iter(selected_span_id);
+        Some(ancestors.into_iter().chain(self_and_descendants).collect())
+    } else {
+        // There's no selected span, render the selected trace's entire tree
+        otel_view
+            .trace_list
+            .selection()
+            .map(|trace_id| data.trace_iter(trace_id).collect())
     }
 }

--- a/src/update/select_span.rs
+++ b/src/update/select_span.rs
@@ -1,0 +1,28 @@
+use crate::{
+    app_state::AppState,
+    states::{Action, InspectOption, WidgetSlot},
+    update::Update,
+};
+use ratatui::crossterm::event::KeyCode;
+
+/// The Update fn for selecting the focused span.
+pub struct SelectSpanUpdate;
+impl Update for SelectSpanUpdate {
+    fn update(&self, action: &Action, s: &mut AppState) -> Vec<Action> {
+        if !matches!(action, Action::Key(KeyCode::Enter)) {
+            return Vec::new();
+        }
+
+        if s.slot_focus != WidgetSlot::Details || *s.inspect_option.current() != InspectOption::Otel
+        {
+            return Vec::new();
+        }
+
+        if let Some(focused_span) = &s.otel_view.focused_span {
+            // Set the currently focused span as the selected
+            s.otel_view.selected_span = Some(focused_span.clone());
+        }
+
+        Vec::new()
+    }
+}

--- a/src/update/tick.rs
+++ b/src/update/tick.rs
@@ -1,0 +1,16 @@
+use crate::{app_state::AppState, states::Action, update::Update};
+
+/// The Update fn for each TUI tick.
+pub struct TickUpdate;
+impl Update for TickUpdate {
+    // TODO: Other calculating of whether a sync needs to happen (like a window
+    // size update or layout change) should likely live here.
+    fn update(&self, a: &Action, _: &mut AppState) -> Vec<Action> {
+        if *a != Action::Tick {
+            return Vec::new();
+        };
+        // The list of actions that should happen each tick. We assume that each
+        // corresponding Update impls its own 'efficiency' guard.
+        vec![Action::SyncTraceGraph]
+    }
+}

--- a/src/update/trace_graph.rs
+++ b/src/update/trace_graph.rs
@@ -1,0 +1,12 @@
+use crate::{app_state::AppState, states::Action, update::Update};
+
+/// The Update fn for sync'ing the TraceGraph.
+pub struct TraceGraphUpdate;
+impl Update for TraceGraphUpdate {
+    fn update(&self, a: &Action, s: &mut AppState) -> Vec<Action> {
+        if *a == Action::SyncTraceGraph {
+            s.otel_view.sync_state();
+        }
+        Vec::new()
+    }
+}


### PR DESCRIPTION
This PR adds update functions that are triggered to update the AppState with regards to the TraceGraph. This includes
* Updates to the underlying TraceGraph (determined per tick),
* Scrolling the trace list,
* Scrolling the span tree, and
* Selecting a span in the tree