### PR TITLE
wip: add otel-based views

### DIFF
--- a/src/controller/layout.rs
+++ b/src/controller/layout.rs
@@ -152,9 +152,25 @@ fn build_otel_header_ls(_s: &AppState) -> LayoutSpec {
     }
 }
 
-fn build_otel_body_ls(_s: &AppState) -> LayoutSpec {
+fn build_otel_body_ls(app_state: &AppState) -> LayoutSpec {
     LayoutSpec {
-        direction: Direction::Vertical,
-        constraints: vec![(Constraint::Fill(1), Left(WidgetSlot::Details))],
+        direction: Direction::Horizontal,
+        constraints: vec![
+            (Constraint::Percentage(10), Left(WidgetSlot::List)),
+            (
+                Constraint::Percentage(90),
+                Right(build_otel_details_ls(app_state)),
+            ),
+        ],
+    }
+}
+
+fn build_otel_details_ls(_s: &AppState) -> LayoutSpec {
+    LayoutSpec {
+        direction: Direction::Horizontal,
+        constraints: vec![
+            (Constraint::Percentage(70), Left(WidgetSlot::Details)),
+            (Constraint::Percentage(30), Left(WidgetSlot::SubDetails)),
+        ],
     }
 }

--- a/src/model/dynamic_list.rs
+++ b/src/model/dynamic_list.rs
@@ -4,11 +4,20 @@ use crate::update::scroll::{ScrollDirection, ScrollableList};
 /// change. To that end this
 /// 1. Efficiently scrolls up and down and
 /// 2. Retains the currently selected item
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct DynamicList<T: Clone + PartialEq> {
     items: Vec<T>,
     /// The index of the selected item.
     selected_index: Option<usize>,
+}
+
+impl<T: Clone + PartialEq> Default for DynamicList<T> {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            selected_index: None,
+        }
+    }
 }
 
 impl<T: Clone + PartialEq> DynamicList<T> {
@@ -16,7 +25,7 @@ impl<T: Clone + PartialEq> DynamicList<T> {
     /// (by value) if the item still exists in the new list.
     pub fn set_items(&mut self, items: Vec<T>) {
         // Get the value of the current selection before replacing the items.
-        let old_selection = self.selection().cloned();
+        let old_selection = self.selected_item().cloned();
         self.items = items;
 
         // After updating items, find the old selection in the new list.
@@ -25,13 +34,17 @@ impl<T: Clone + PartialEq> DynamicList<T> {
             .and_then(|selected| self.items.iter().position(|item| item == selected));
     }
 
+    pub fn selected_index(&self) -> Option<usize> {
+        self.selected_index
+    }
+
     /// Returns a reference to the currently selected item.
-    pub fn selection(&self) -> Option<&T> {
+    pub fn selected_item(&self) -> Option<&T> {
         self.selected_index.and_then(|i| self.items.get(i))
     }
 
     /// Returns a reference to the items as a slice.
-    pub fn _items(&self) -> &[T] {
+    pub fn items(&self) -> &[T] {
         &self.items
     }
 

--- a/src/model/otel_view.rs
+++ b/src/model/otel_view.rs
@@ -1,6 +1,10 @@
 use crate::{
     model::dynamic_list::DynamicList,
-    otel::{SpanId, TraceId, graph::TraceGraph, span_ext::SpanExt},
+    otel::{
+        graph::TraceGraph,
+        id::{SpanId, TraceId},
+        span_ext::SpanExt,
+    },
 };
 use arc_swap::ArcSwap;
 use opentelemetry_proto::tonic::trace::v1::Span;
@@ -74,7 +78,7 @@ impl OtelViewState {
             .sort_unstable_by_key(|id| Reverse(latest_data.traces.get(id).unwrap().start_time()));
         self.trace_list.set_items(trace_ids);
 
-        if self.trace_list.selection().is_none() {
+        if self.trace_list.selected_item().is_none() {
             // Trace selection was lost (because the trace was evicted), clear the
             // dependent span states
             self.focused_span = None;
@@ -99,7 +103,7 @@ impl OtelViewState {
             // Check if the currently selected trace contains the span
             if self
                 .trace_list
-                .selection()
+                .selected_item()
                 .is_some_and(|trace_id| is_span_in_trace(data, trace_id, &span.span_id()))
             {
                 // It's still valid (in the trace), put it back

--- a/src/otel/ancestor_iter.rs
+++ b/src/otel/ancestor_iter.rs
@@ -1,10 +1,9 @@
+use crate::otel::graph::TraceGraph;
+use crate::otel::id::SpanId;
+use crate::otel::span_ext::SpanExt;
 use opentelemetry_proto::tonic::trace::v1::Span;
 use std::collections::HashMap;
 use std::sync::Arc;
-
-use crate::otel::SpanId;
-use crate::otel::graph::TraceGraph;
-use crate::otel::span_ext::SpanExt;
 
 /// An iterator that walks *up* the span's ancestor trace starting with its
 /// parent (unlike TraceIter).

--- a/src/otel/evictor.rs
+++ b/src/otel/evictor.rs
@@ -1,5 +1,5 @@
-use crate::otel::TraceId;
 use crate::otel::graph::{TraceGraph, TraceInfo};
+use crate::otel::id::TraceId;
 use crate::otel::orphanage::Orphanage;
 use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime};

--- a/src/otel/graph.rs
+++ b/src/otel/graph.rs
@@ -1,7 +1,8 @@
 use crate::otel::ancestor_iter::AncestorIter;
+use crate::otel::id::{SpanId, TraceId};
 use crate::otel::span_ext::SpanExt;
 use crate::otel::trace_iter::TraceIter;
-use crate::otel::{SpanId, SubTree, TraceId, TraceMeta};
+use crate::otel::{SubTree, TraceMeta};
 use opentelemetry_proto::tonic::trace::v1::Span;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -81,11 +82,7 @@ impl TraceGraph {
                 .or_default()
                 .push(span_id);
         } else {
-            error!(
-                "Unexpected: no parent {} for child {}",
-                hex::encode(parent_id),
-                hex::encode(span_id)
-            );
+            error!("Unexpected: no parent {} for child {}", parent_id, span_id);
         }
 
         // Add the span to subtrees
@@ -113,7 +110,7 @@ impl TraceGraph {
                     break;
                 }
             } else {
-                error!("Unexpected: no span {}", hex::encode(span_id));
+                error!("Unexpected: no span {}", span_id);
                 break;
             }
         }
@@ -125,7 +122,7 @@ impl TraceGraph {
 
         if ids_to_remove.is_empty() {
             if self.traces.remove(trace_id).is_none() {
-                error!("Unexpected: no trace meta {}", hex::encode(trace_id));
+                error!("Unexpected: no trace meta {}", trace_id);
             }
             return Vec::new();
         }

--- a/src/otel/id.rs
+++ b/src/otel/id.rs
@@ -1,0 +1,30 @@
+use std::fmt;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Id<const N: usize>(pub [u8; N]);
+
+pub type SpanId = Id<8>;
+pub type TraceId = Id<16>;
+pub type RootId = SpanId;
+
+impl<const N: usize> fmt::Display for Id<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.0))
+    }
+}
+
+impl<const N: usize> TryFrom<Vec<u8>> for Id<N> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        let actual_len = value.len();
+
+        value.try_into().map(Id).map_err(|_| {
+            anyhow::anyhow!(
+                "Invalid length for id: expected {}, actual {}",
+                N,
+                actual_len
+            )
+        })
+    }
+}

--- a/src/otel/span_ext.rs
+++ b/src/otel/span_ext.rs
@@ -1,4 +1,4 @@
-use crate::otel::{SpanId, TraceId};
+use crate::otel::id::{SpanId, TraceId};
 use opentelemetry_proto::tonic::trace::v1::Span;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -14,18 +14,18 @@ pub trait SpanExt {
 
 impl SpanExt for Span {
     fn span_id(&self) -> SpanId {
-        self.span_id.clone().try_into().unwrap_or_default()
+        self.span_id.clone().try_into().unwrap()
     }
 
     fn trace_id(&self) -> TraceId {
-        self.trace_id.clone().try_into().unwrap_or_default()
+        self.trace_id.clone().try_into().unwrap()
     }
 
     fn parent_id(&self) -> Option<SpanId> {
         if self.parent_span_id.is_empty() {
             None
         } else {
-            Some(self.parent_span_id.clone().try_into().unwrap_or_default())
+            Some(self.parent_span_id.clone().try_into().unwrap())
         }
     }
 

--- a/src/otel/store.rs
+++ b/src/otel/store.rs
@@ -1,5 +1,5 @@
 use crate::otel::{
-    TraceId, evictor::Evictor, graph::TraceGraph, orphanage::Orphanage, span_ext::SpanExt,
+    evictor::Evictor, graph::TraceGraph, id::TraceId, orphanage::Orphanage, span_ext::SpanExt,
 };
 use opentelemetry_proto::tonic::trace::v1::Span;
 use std::time::Duration;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ use amaru_kernel::{Bytes, CertificatePointer, Hash, KeyValuePairs, Nullable, Rat
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use std::fmt;
+use std::time::Duration;
 
 pub mod to_list_item;
 pub mod to_rich;
@@ -225,5 +226,20 @@ impl ToRichText for CertificatePointer {
             Style::default(),
         ));
         RichText::Lines(lines)
+    }
+}
+
+/// Formats a duration for human-reading.
+/// If (1 second <= the duration), it formats as seconds;
+/// If (1 millisecond <= the duration < 1 second), it formats as milliseconds;
+/// and otherwise it formats as microseconds.
+pub fn format_duration(duration: Duration) -> String {
+    let micros = duration.as_micros();
+    if micros >= 1_000_000 {
+        format!("{:.3} s", duration.as_secs_f64())
+    } else if micros >= 1000 {
+        format!("{:.3} ms", micros as f64 / 1000.0)
+    } else {
+        format!("{} µs", micros)
     }
 }

--- a/src/ui/to_rich/mod.rs
+++ b/src/ui/to_rich/mod.rs
@@ -1,3 +1,6 @@
+use crate::ui::RichText;
+use ratatui::text::Line;
+
 pub mod account;
 pub mod block_issuer;
 pub mod drep;
@@ -5,4 +8,11 @@ pub mod header;
 pub mod nonces;
 pub mod pool;
 pub mod proposal;
+pub mod span;
 pub mod utxo;
+
+impl From<Vec<Line<'static>>> for RichText {
+    fn from(lines: Vec<Line<'static>>) -> Self {
+        RichText::Lines(lines)
+    }
+}

--- a/src/ui/to_rich/span.rs
+++ b/src/ui/to_rich/span.rs
@@ -1,0 +1,136 @@
+use crate::{
+    otel::span_ext::SpanExt,
+    ui::{
+        RichText, ToRichText, format_duration, labeled_default, labeled_default_opt_single,
+        labeled_default_single,
+    },
+};
+use chrono::{TimeZone, Utc};
+use opentelemetry_proto::tonic::{
+    common::v1::{AnyValue, KeyValue, any_value::Value},
+    trace::v1::{Span, span::Event},
+};
+use ratatui::text::Line;
+
+struct Attributes<'a>(&'a [KeyValue]);
+struct Events<'a>(&'a [Event]);
+
+impl ToRichText for Span {
+    fn to_rich_text(&self) -> RichText {
+        let mut lines = Vec::new();
+
+        lines.extend(labeled_default_single("Name", &self.name));
+        lines.extend(labeled_default_single("Span Id", self.span_id()));
+        lines.extend(labeled_default_single("Trace Id", self.trace_id()));
+        lines.extend(labeled_default_opt_single("Parent Id", self.parent_id()));
+        lines.extend(labeled_default_single("Kind", format_span_kind(self.kind)));
+        lines.extend(labeled_default_opt_single(
+            "Status",
+            self.status
+                .as_ref()
+                .map(|s| format!("{} - {}", format_status_code(s.code), s.message)),
+        ));
+        let start_time = Utc.timestamp_nanos(self.start_time_unix_nano as i64);
+        lines.extend(labeled_default_single(
+            "Start",
+            start_time.format("%H:%M:%S%.6f").to_string(),
+        ));
+        lines.extend(labeled_default_single(
+            "Duration",
+            format_duration(self.duration()),
+        ));
+
+        if !self.attributes.is_empty() {
+            lines.extend(labeled_default("Attributes", &Attributes(&self.attributes)));
+        }
+
+        if !self.events.is_empty() {
+            lines.extend(labeled_default("Events", &Events(&self.events)));
+        }
+
+        lines.into()
+    }
+}
+
+impl<'a> ToRichText for Attributes<'a> {
+    fn to_rich_text(&self) -> RichText {
+        self.0
+            .iter()
+            .map(|attr| {
+                Line::from(format!(
+                    "  - {}: {}",
+                    attr.key,
+                    format_any_value(&attr.value)
+                ))
+            })
+            .collect()
+    }
+}
+
+impl<'a> ToRichText for Events<'a> {
+    fn to_rich_text(&self) -> RichText {
+        self.0
+            .iter()
+            .flat_map(|event| event.to_rich_text().unwrap_lines())
+            .collect()
+    }
+}
+
+impl ToRichText for Event {
+    fn to_rich_text(&self) -> RichText {
+        let mut lines = Vec::new();
+        let event_time = Utc.timestamp_nanos(self.time_unix_nano as i64);
+        lines.push(Line::from(format!(
+            "  - {} @ {}",
+            self.name,
+            event_time.format("%H:%M:%S%.6f")
+        )));
+        lines.extend(labeled_default("Attributes", &Attributes(&self.attributes)));
+        lines.into()
+    }
+}
+
+fn format_any_value(value: &Option<AnyValue>) -> String {
+    let Some(any_value) = value else {
+        return String::from("<None>");
+    };
+    let Some(v) = &any_value.value else {
+        return String::from("<None>");
+    };
+
+    match v {
+        Value::StringValue(s) => s.clone(),
+        Value::BoolValue(b) => b.to_string(),
+        Value::IntValue(i) => i.to_string(),
+        Value::DoubleValue(d) => d.to_string(),
+        // TODO: Impl these recursively ?
+        Value::ArrayValue(a) => format!("[{} items]", a.values.len()),
+        Value::KvlistValue(k) => format!("{{{} items}}", k.values.len()),
+        Value::BytesValue(b) => format!("[{} bytes]", b.len()),
+    }
+}
+
+/// Format's the SpanKind to be human readable. See otel's protobuf spec, it's in
+/// `trace.proto`.
+fn format_span_kind(kind: i32) -> &'static str {
+    match kind {
+        0 => "Unspecified",
+        1 => "Internal",
+        2 => "Server",
+        3 => "Client",
+        4 => "Producer",
+        5 => "Consumer",
+        _ => "Unknown", // Not value in the spec
+    }
+}
+
+/// Format's the StatusCode to be human readable. See otel's protobuf spec, it's in
+/// `trace.proto`.
+fn format_status_code(code: i32) -> &'static str {
+    match code {
+        0 => "Unset",
+        1 => "Ok",
+        2 => "Error",
+        _ => "Unknown", // Not value in the spec
+    }
+}

--- a/src/update/scroll.rs
+++ b/src/update/scroll.rs
@@ -3,7 +3,7 @@ use crate::{
     model::{
         cursor::Cursor, ledger_view::LedgerViewState, otel_view::OtelViewState, window::WindowState,
     },
-    otel::{SpanId, graph::TraceGraph, span_ext::SpanExt},
+    otel::{graph::TraceGraph, id::SpanId, span_ext::SpanExt},
     states::{Action, InspectOption, LedgerBrowse, LedgerMode, WidgetSlot},
     update::Update,
 };
@@ -89,7 +89,7 @@ impl Update for ScrollUpdate {
                     let new_focused_span = s
                         .otel_view
                         .trace_list
-                        .selection()
+                        .selected_item()
                         .and_then(|trace_id| graph.traces.get(trace_id))
                         .and_then(|trace_meta| trace_meta.roots().first_key_value())
                         .and_then(|(_, root_ids)| root_ids.first())
@@ -195,7 +195,7 @@ fn get_ordered_spans_for_view(data: &TraceGraph, otel_view: &OtelViewState) -> O
         // There's no selected span, render the selected trace's entire tree
         otel_view
             .trace_list
-            .selection()
+            .selected_item()
             .map(|trace_id| data.trace_iter(trace_id).collect())
     }
 }

--- a/src/view/defs.rs
+++ b/src/view/defs.rs
@@ -1,5 +1,8 @@
 use crate::view::block::render_block;
+use crate::view::flame_graph::render_flame_graph;
 use crate::view::nonces::render_nonces;
+use crate::view::span::render_span;
+use crate::view::trace_list::render_traces;
 use crate::{
     app_state::AppState,
     controller::is_widget_focused,
@@ -308,6 +311,56 @@ impl View for LedgerSearchUtxoDetails {
             s.ledger_view.utxos_by_addr_search.get_current_res(),
             is_widget_focused(s, self.slot()),
         )
+    }
+}
+
+pub struct TraceList;
+impl View for TraceList {
+    fn slot(&self) -> WidgetSlot {
+        WidgetSlot::List
+    }
+
+    fn is_visible(&self, s: &AppState) -> bool {
+        *s.inspect_option.current() == InspectOption::Otel
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect, s: &AppState) -> Result<()> {
+        render_traces(
+            frame,
+            area,
+            &s.otel_view.trace_list,
+            is_widget_focused(s, self.slot()),
+        )
+    }
+}
+
+pub struct FlameGraphDetails;
+impl View for FlameGraphDetails {
+    fn slot(&self) -> WidgetSlot {
+        WidgetSlot::Details
+    }
+
+    fn is_visible(&self, s: &AppState) -> bool {
+        *s.inspect_option.current() == InspectOption::Otel
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect, s: &AppState) -> Result<()> {
+        render_flame_graph(frame, area, &s.otel_view, is_widget_focused(s, self.slot()))
+    }
+}
+
+pub struct SpanDetails;
+impl View for SpanDetails {
+    fn slot(&self) -> WidgetSlot {
+        WidgetSlot::SubDetails
+    }
+
+    fn is_visible(&self, s: &AppState) -> bool {
+        *s.inspect_option.current() == InspectOption::Otel
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect, s: &AppState) -> Result<()> {
+        render_span(frame, area, &s.otel_view, is_widget_focused(s, self.slot()))
     }
 }
 

--- a/src/view/flame_graph.rs
+++ b/src/view/flame_graph.rs
@@ -1,0 +1,137 @@
+use crate::{
+    model::otel_view::OtelViewState,
+    otel::{
+        TreeBounds,
+        graph::TraceGraph,
+        id::{SpanId, TraceId},
+        span_ext::SpanExt,
+    },
+    view::span_bar::SpanBarRenderer,
+};
+use anyhow::{Result, anyhow};
+use opentelemetry_proto::tonic::trace::v1::Span;
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Paragraph},
+};
+use std::{iter, sync::Arc};
+
+/// Renders the flame graph widget.
+pub fn render_flame_graph(
+    frame: &mut Frame,
+    area: Rect,
+    state: &OtelViewState,
+    is_focused: bool,
+) -> Result<()> {
+    let mut block = Block::default()
+        .title("Trace Details")
+        .borders(Borders::ALL);
+    if is_focused {
+        block = block.border_style(Style::default().fg(Color::Blue));
+    }
+
+    let lines = get_flame_graph_lines(state, area.width.saturating_sub(2) as usize)?;
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+    Ok(())
+}
+
+/// Determines which view to render based on the app state.
+fn get_flame_graph_lines(
+    state: &OtelViewState,
+    max_bar_width: usize,
+) -> Result<Vec<Line<'static>>> {
+    if let Some(selected_span) = &state.selected_span {
+        // A Span is selected
+        get_span_tree_lines(state, selected_span, max_bar_width)
+    } else if let Some(trace_id) = state.trace_list.selected_item() {
+        // No Span is selected but a Trace is selected
+        get_trace_tree_lines(state, trace_id, max_bar_width)
+    } else {
+        Ok(vec![Line::from("No Trace selected.")])
+    }
+}
+
+/// Gets the lines for the Span tree view, including the Span's ancestors and descendants.
+fn get_span_tree_lines(
+    state: &OtelViewState,
+    selected_span: &Arc<Span>,
+    max_bar_width: usize,
+) -> Result<Vec<Line<'static>>> {
+    let graph = &state.trace_graph_source.load();
+    let selected_span_id = selected_span.span_id();
+
+    let Some(span_tree) = graph.subtrees.get(&selected_span_id) else {
+        return Err(anyhow!(
+            "Unexpected: Subtree not found for Span {}",
+            selected_span_id
+        ));
+    };
+
+    let mut ancestors: Vec<SpanId> = graph.ancestor_iter(selected_span_id).collect();
+    // We want the list to start from the root and go down to the span's parent
+    ancestors.reverse();
+    let descendants = graph.descendent_iter(selected_span_id);
+
+    get_lines(
+        graph,
+        state,
+        span_tree.bounds(),
+        max_bar_width,
+        ancestors.into_iter(),
+        descendants,
+    )
+}
+
+/// Gets the lines for the Trace view, each Root's tree.
+fn get_trace_tree_lines(
+    state: &OtelViewState,
+    trace_id: &TraceId,
+    max_bar_width: usize,
+) -> Result<Vec<Line<'static>>> {
+    let graph = &state.trace_graph_source.load();
+
+    let Some(trace_meta) = graph.traces.get(trace_id) else {
+        return Err(anyhow!("Unexpected: Trace {} not found", trace_id));
+    };
+    let (Some(start), Some(end)) = (trace_meta.start_time(), trace_meta.end_time(graph)) else {
+        return Err(anyhow!(
+            "Unexpected: Trace {} is missing start or end time",
+            trace_id
+        ));
+    };
+
+    let bounds = &TreeBounds { start, end };
+    let descendants = graph.trace_iter(trace_id);
+
+    // A Trace has no ancestors, so we pass an empty iter
+    get_lines(
+        graph,
+        state,
+        bounds,
+        max_bar_width,
+        iter::empty(),
+        descendants,
+    )
+}
+
+/// Gets the span bar lines for an ancestor list and a descendant list.
+fn get_lines(
+    graph: &TraceGraph,
+    state: &OtelViewState,
+    bounds: &TreeBounds,
+    max_bar_width: usize,
+    ancestors: impl Iterator<Item = SpanId>,
+    descendants: impl Iterator<Item = SpanId>,
+) -> Result<Vec<Line<'static>>> {
+    let renderer = SpanBarRenderer::new(graph, state, bounds, max_bar_width)?;
+
+    let tagged_ancestors = ancestors.map(|id| (id, true));
+    let tagged_descendants = descendants.map(|id| (id, false));
+
+    tagged_ancestors
+        .chain(tagged_descendants)
+        .map(|(id, is_ancestor)| renderer.render(&id, is_ancestor))
+        .collect()
+}

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -6,11 +6,15 @@ use std::collections::HashMap;
 pub mod block;
 pub mod defs;
 pub mod details;
+pub mod flame_graph;
 pub mod header;
 pub mod line;
 pub mod nonces;
 pub mod search;
+pub mod span;
+pub mod span_bar;
 pub mod tabs;
+pub mod trace_list;
 pub mod window;
 
 pub trait View: Sync {
@@ -43,6 +47,9 @@ static VIEW_DEFS: &[&dyn View] = &[
     &ChainSearchHeader,
     &ChainSearchBlock,
     &ChainSearchNonces,
+    &TraceList,
+    &FlameGraphDetails,
+    &SpanDetails,
     &BottomLine,
 ];
 

--- a/src/view/span.rs
+++ b/src/view/span.rs
@@ -1,0 +1,29 @@
+use crate::{model::otel_view::OtelViewState, ui::ToRichText};
+use anyhow::Result;
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Paragraph},
+};
+
+pub fn render_span(
+    frame: &mut Frame,
+    area: Rect,
+    state: &OtelViewState,
+    is_focused: bool,
+) -> Result<()> {
+    let mut block = Block::default().title("Span Details").borders(Borders::ALL);
+    if is_focused {
+        block = block.border_style(Style::default().fg(Color::Blue));
+    }
+
+    let lines = if let Some(focused_span) = &state.focused_span {
+        focused_span.to_rich_text().unwrap_lines()
+    } else {
+        vec![Line::from("No span focused.")]
+    };
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+
+    Ok(())
+}

--- a/src/view/span_bar.rs
+++ b/src/view/span_bar.rs
@@ -1,0 +1,149 @@
+use crate::{
+    model::otel_view::OtelViewState,
+    otel::{TreeBounds, graph::TraceGraph, id::SpanId, span_ext::SpanExt},
+    ui::format_duration,
+};
+use anyhow::{Result, anyhow};
+use opentelemetry_proto::tonic::trace::v1::Span as OtelSpan;
+use ratatui::prelude::*;
+use std::{sync::Arc, time::Duration};
+
+/// Holds the context needed to render a Span bar
+pub struct SpanBarRenderer<'a> {
+    graph: &'a TraceGraph,
+    state: &'a OtelViewState,
+    tree_bounds: &'a TreeBounds,
+    max_render_width: usize,
+    scale: f64,
+}
+
+impl<'a> SpanBarRenderer<'a> {
+    /// Creates a new SpanBarRenderer.
+    pub fn new(
+        graph: &'a TraceGraph,
+        state: &'a OtelViewState,
+        tree_bounds: &'a TreeBounds,
+        max_render_width: usize,
+    ) -> Result<Self> {
+        let tree_duration = tree_bounds.duration();
+        if tree_duration.is_zero() {
+            return Err(anyhow!(
+                "Illegal: Cannot create renderer with a 0-duration TreeBounds"
+            ));
+        }
+        Ok(Self {
+            graph,
+            state,
+            tree_bounds,
+            max_render_width,
+            scale: (max_render_width as f64) / tree_duration.as_micros() as f64,
+        })
+    }
+
+    /// Renders a single span bar.
+    pub fn render(&self, span_id: &SpanId, is_ancestor: bool) -> Result<Line<'static>> {
+        let span = self
+            .graph
+            .spans
+            .get(span_id)
+            .ok_or_else(|| anyhow!("Unexpected: span {} not found", span_id))?;
+
+        let (bar_offset, bar_width) = if is_ancestor {
+            // Ancestors take up the full width
+            (0, self.max_render_width)
+        } else {
+            let (offset, num_chars_uncapped) = get_span_layout(span, self.tree_bounds, self.scale)?;
+            // The available width is what's left of the screen after the offset
+            let available_width = self.max_render_width.saturating_sub(offset);
+            // Cap the bar width by the available space
+            let final_width = num_chars_uncapped.min(available_width);
+            (offset, final_width)
+        };
+        if bar_width == 0 {
+            return Err(anyhow!("Illegal: got 0 bar-width for span {}", span_id));
+        }
+
+        let bar_text = get_bar_text(span, bar_width)?;
+        let is_focused = self
+            .state
+            .focused_span
+            .as_ref()
+            .is_some_and(|s| s.span_id() == *span_id);
+
+        let bar_style = get_bar_style(
+            is_focused,
+            is_ancestor,
+            span.duration(),
+            self.tree_bounds.duration(),
+        )?;
+
+        Ok(Line::from(vec![
+            Span::raw(" ".repeat(bar_offset)),
+            Span::styled(bar_text, bar_style),
+        ]))
+    }
+}
+
+/// Calculates the screen x-offset and character width of a span bar.
+fn get_span_layout(
+    span: &OtelSpan,
+    tree_bounds: &TreeBounds,
+    scale: f64,
+) -> Result<(usize, usize)> {
+    let span_start_offset = span
+        .start_time()
+        .duration_since(*tree_bounds.start())
+        .map_err(|e| anyhow!("Illegal: Span start time is before tree bounds start time: {e}"))?;
+
+    let offset_chars = (span_start_offset.as_micros() as f64 * scale).floor() as usize;
+    let num_chars = (span.duration().as_micros() as f64 * scale).ceil().max(1.0) as usize;
+
+    Ok((offset_chars, num_chars))
+}
+
+/// Gets the style for a span bar based on its state.
+fn get_bar_style(
+    is_focused: bool,
+    is_ancestor: bool,
+    span_duration: Duration,
+    tree_duration: Duration,
+) -> Result<Style> {
+    if is_focused {
+        return Ok(Style::default().fg(Color::Black).bg(Color::LightCyan));
+    }
+    if is_ancestor {
+        return Ok(Style::default().bg(Color::DarkGray).fg(Color::Gray));
+    }
+    let bg_color = get_bar_color(tree_duration, span_duration)?;
+    Ok(Style::default().fg(Color::White).bg(bg_color))
+}
+
+/// Gets the color for the span bar based on its duration and the total trace duration.
+fn get_bar_color(max_duration: Duration, duration: Duration) -> Result<Color> {
+    if max_duration.is_zero() {
+        return Err(anyhow!("Illegal: got a 0 max duration for coloring"));
+    }
+    let ratio = (duration.as_micros() as f64 / max_duration.as_micros() as f64).sqrt();
+    let hot = (210, 100, 80); // Reddish-orange
+    let cold = (80, 120, 180); // Blueish
+    let r = (cold.0 as f64 * (1.0 - ratio) + hot.0 as f64 * ratio) as u8;
+    let g = (cold.1 as f64 * (1.0 - ratio) + hot.1 as f64 * ratio) as u8;
+    let b = (cold.2 as f64 * (1.0 - ratio) + hot.2 as f64 * ratio) as u8;
+    Ok(Color::Rgb(r, g, b))
+}
+
+/// Gets the text label to be displayed inside a span bar.
+fn get_bar_text(span: &Arc<OtelSpan>, bar_width: usize) -> Result<String> {
+    if bar_width == 0 {
+        return Err(anyhow!("Illegal: got less than 1 for bar width"));
+    }
+
+    let label = format!(" {} ({})", span.name, format_duration(span.duration()));
+
+    if label.len() <= bar_width {
+        // The label will fit
+        return Ok(format!("{:<width$}", label, width = bar_width));
+    }
+
+    Ok(format!("{}…", &label[..bar_width - 1]))
+}

--- a/src/view/trace_list.rs
+++ b/src/view/trace_list.rs
@@ -1,0 +1,36 @@
+use crate::{model::dynamic_list::DynamicList, otel::id::TraceId};
+use anyhow::Result;
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, List, ListItem, ListState},
+};
+
+pub fn render_traces(
+    frame: &mut Frame,
+    area: Rect,
+    list: &DynamicList<TraceId>,
+    is_focused: bool,
+) -> Result<()> {
+    let mut block = Block::default().title("Traces").borders(Borders::ALL);
+    if is_focused {
+        block = block.border_style(Style::default().fg(Color::Blue));
+    }
+
+    let items: Vec<ListItem> = list
+        .items()
+        .iter()
+        .map(ToString::to_string)
+        .map(ListItem::new)
+        .collect();
+
+    let widget = List::new(items)
+        .highlight_symbol(">> ")
+        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
+        .block(block);
+
+    let mut state = ListState::default();
+    state.select(list.selected_index());
+    frame.render_stateful_widget(widget, area, &mut state);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the OTEL-based views: the OTEL layout, the Trace list, the Trace details, and the Span details. With this PR a user can "scroll" the Trace details and "select" a Span for a "zoomed-in" view.