### PR TITLE
feat: add pool render; pause emacs keybindings

### DIFF
--- a/.config/config.json5
+++ b/.config/config.json5
@@ -1,7 +1,6 @@
 {
   "keybindings": {
     "Home": {
-      "Esc": "Quit", // Quit
       "<Ctrl-d>": "Quit", // Another way to quit
       "<Ctrl-c>": "Quit", // Yet another way to quit
       "<Ctrl-z>": "Suspend", // Suspend the application
@@ -11,10 +10,11 @@
       "<Shift-Down>": "FocusDown",
       "<Shift-Left>": "FocusLeft",
       "<Shift-Right>": "FocusRight",
-      "k": "FocusUp",
-      "j": "FocusDown",
-      "h": "FocusLeft",
-      "l": "FocusRight",
+      // TODO: Add a mode so that these keys don't interrupt Search
+      // "k": "FocusUp",
+      // "j": "FocusDown",
+      // "h": "FocusLeft",
+      // "l": "FocusRight",
     },
   }
 }

--- a/src/ui/to_rich/account.rs
+++ b/src/ui/to_rich/account.rs
@@ -42,6 +42,18 @@ impl ToRichText for Row {
         let mut lines = Vec::new();
 
         lines.extend(labeled(
+            "Pool".to_string(),
+            self.pool
+                .map(|(pool_id, cert_ptr)| {
+                    let mut lines = RichText::Single(Span::raw(pool_id.to_string())).unwrap_lines();
+                    lines.extend(cert_ptr.to_rich_text().unwrap_lines());
+                    RichText::Lines(lines)
+                })
+                .unwrap_or_else(|| RichText::Single(Span::raw("None"))),
+            Style::default().fg(Color::Yellow),
+        ));
+
+        lines.extend(labeled(
             "Deposit".to_string(),
             RichText::Single(Span::raw(format!("{} lovelace", self.deposit))),
             Style::default(),


### PR DESCRIPTION
This is a mini-PR that adds PoolId and CertPtr rendering. It also pauses emacs bindings (h, j, k, l) because it currently interferes with Search.