### PR TITLE
feat: add prometheus metrics reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,9 @@ dependencies = [
  "pallas-codec",
  "pallas-primitives",
  "pretty_assertions",
+ "prometheus-parse",
  "ratatui",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_plain",
@@ -810,6 +812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1348,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2495,6 +2522,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,11 +2551,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2520,12 +2580,16 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2724,10 +2788,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3057,6 +3146,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,6 +3339,50 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -3610,6 +3760,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools 0.12.1",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,6 +3975,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3892,6 +4108,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3913,10 +4162,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -4005,6 +4286,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4267,6 +4560,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4291,6 +4587,27 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4464,6 +4781,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4571,6 +4908,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -4774,6 +5129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4963,6 +5324,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4992,6 +5366,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5126,6 +5510,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,9 @@ opentelemetry-proto = "0.30.0"
 pallas-codec = "0.33.0"
 pallas-primitives = "0.33.0"
 pretty_assertions = "1.4.1"
+prometheus-parse = "0.2.5"
 ratatui = { version = "0.29.0", features = ["serde", "macros"] }
+reqwest = "0.12.23"
 serde = { version = "1.0.226", features = ["derive"] }
 serde_json = "1.0.145"
 serde_plain = "1.0.2"

--- a/src/controller/layout.rs
+++ b/src/controller/layout.rs
@@ -6,11 +6,13 @@ use crate::{
 use either::Either::{Left, Right};
 use ratatui::layout::{Constraint, Direction};
 
+// TODO: Use a builder in here
 pub fn build_layout_spec(app_state: &AppState) -> LayoutSpec {
     match app_state.inspect_option.current() {
         InspectOption::Ledger => build_ledger_ls(app_state),
         InspectOption::Chain => build_chain_ls(app_state),
         InspectOption::Otel => build_otel_ls(app_state),
+        InspectOption::Prometheus => build_prom_ls(app_state),
     }
 }
 
@@ -172,5 +174,42 @@ fn build_otel_details_ls(_s: &AppState) -> LayoutSpec {
             (Constraint::Percentage(70), Left(WidgetSlot::Details)),
             (Constraint::Percentage(30), Left(WidgetSlot::SubDetails)),
         ],
+    }
+}
+
+fn build_prom_ls(app_state: &AppState) -> LayoutSpec {
+    LayoutSpec {
+        direction: Direction::Vertical,
+        constraints: vec![
+            (Constraint::Fill(1), Right(build_prom_rest_ls(app_state))),
+            (Constraint::Length(1), Left(WidgetSlot::BottomLine)),
+        ],
+    }
+}
+
+fn build_prom_rest_ls(app_state: &AppState) -> LayoutSpec {
+    LayoutSpec {
+        direction: Direction::Vertical,
+        constraints: vec![
+            (
+                Constraint::Length(3),
+                Right(build_prom_header_ls(app_state)),
+            ),
+            (Constraint::Fill(1), Right(build_prom_body_ls(app_state))),
+        ],
+    }
+}
+
+fn build_prom_header_ls(_s: &AppState) -> LayoutSpec {
+    LayoutSpec {
+        direction: Direction::Horizontal,
+        constraints: vec![(Constraint::Fill(1), Left(WidgetSlot::InspectOption))],
+    }
+}
+
+fn build_prom_body_ls(_: &AppState) -> LayoutSpec {
+    LayoutSpec {
+        direction: Direction::Horizontal,
+        constraints: vec![(Constraint::Fill(1), Left(WidgetSlot::Details))],
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod detection;
 pub mod logging;
 mod model;
 pub mod otel;
+pub mod prometheus;
 mod states;
 mod store;
 pub mod tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,30 @@
+use std::time::Duration;
+
 use amaru_doctor::{
-    app::App,
-    cli::Cli,
-    open_chain_db, open_ledger_db,
-    otel::{ingestor::TraceIngestor, service::AmaruTraceService},
-    tui::Tui,
+    app::App, cli::Cli, open_chain_db, open_ledger_db, otel::service::OtelCollectorService,
+    prometheus::service::MetricsPoller, tui::Tui,
 };
 use anyhow::Result;
 use clap::Parser;
-use opentelemetry_proto::tonic::collector::trace::v1::trace_service_server::TraceServiceServer;
-use std::time::Duration;
-use tokio::task;
-use tonic::transport::Server;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     amaru_doctor::logging::init()?;
 
-    let collector = TraceIngestor::new(10_000, Duration::from_secs(10 * 60));
-    let tracegraph_snapshot = collector.snapshot();
-    task::spawn(async move {
-        let addr = "0.0.0.0:4317".parse().unwrap();
-        Server::builder()
-            .add_service(TraceServiceServer::new(AmaruTraceService::new(collector)))
-            .serve(addr)
-            .await
-            .unwrap();
-    });
+    let otel_service = OtelCollectorService::new("0.0.0.0:4317");
+    let otel_handle = otel_service.start();
+
+    let metrics_service = MetricsPoller::new("http://0.0.0.0:8889/metrics", Duration::from_secs(1));
+    let metrics_handle = metrics_service.start();
 
     let args = Cli::parse();
-
     let mut tui = Tui::default().mouse(true);
 
     let mut app: App = App::new(
         open_ledger_db(&args.ledger_db, &args.network)?,
         open_chain_db(&args.chain_db, &args.network)?,
-        tracegraph_snapshot,
+        otel_handle.snapshot,
+        metrics_handle.receiver,
         tui.get_frame().area(),
     )?;
     app.run(&mut tui).await?;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,4 +3,5 @@ pub mod cursor;
 pub mod dynamic_list;
 pub mod ledger_view;
 pub mod otel_view;
+pub mod prom_metrics;
 pub mod window;

--- a/src/model/prom_metrics.rs
+++ b/src/model/prom_metrics.rs
@@ -1,0 +1,27 @@
+use crate::prometheus::model::NodeMetrics;
+use tokio::sync::mpsc::Receiver;
+
+#[derive(Debug)]
+pub struct PromMetricsViewState {
+    receiver: Receiver<NodeMetrics>,
+    latest_metrics: Option<NodeMetrics>,
+}
+
+impl PromMetricsViewState {
+    pub fn new(receiver: Receiver<NodeMetrics>) -> Self {
+        Self {
+            receiver,
+            latest_metrics: None,
+        }
+    }
+
+    pub fn sync(&mut self) {
+        if let Ok(new_metrics) = self.receiver.try_recv() {
+            self.latest_metrics = Some(new_metrics);
+        }
+    }
+
+    pub fn latest_metrics(&self) -> &Option<NodeMetrics> {
+        &self.latest_metrics
+    }
+}

--- a/src/otel/mod.rs
+++ b/src/otel/mod.rs
@@ -1,9 +1,9 @@
+use crate::otel::graph::TraceGraph;
+use crate::otel::id::{RootId, SpanId};
+use arc_swap::ArcSwap;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
-
-use crate::otel::graph::TraceGraph;
-use crate::otel::id::{RootId, SpanId};
 
 pub mod ancestor_iter;
 pub mod evictor;
@@ -16,6 +16,9 @@ pub mod service;
 pub mod span_ext;
 pub mod store;
 pub mod trace_iter;
+pub mod trace_service;
+
+pub type TraceGraphSnapshot = Arc<ArcSwap<TraceGraph>>;
 
 /// The start and end times for a trace tree.
 #[derive(Copy, Clone, Debug)]

--- a/src/otel/trace_service.rs
+++ b/src/otel/trace_service.rs
@@ -1,0 +1,43 @@
+use crate::otel::ingestor::TraceIngestor;
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse, trace_service_server::TraceService,
+};
+use tonic::{Request, Response, Status};
+
+pub struct AmaruTraceService {
+    ingestor: TraceIngestor,
+}
+
+impl AmaruTraceService {
+    pub fn new(collector: TraceIngestor) -> Self {
+        Self {
+            ingestor: collector,
+        }
+    }
+}
+
+/// The main entry-point for accepting amaru OTEL data.
+#[tonic::async_trait]
+impl TraceService for AmaruTraceService {
+    async fn export(
+        &self,
+        req: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        // Flatten spans into a single Vec
+        let mut all_spans = Vec::new();
+        for r_spans in req.into_inner().resource_spans {
+            for s_spans in r_spans.scope_spans {
+                all_spans.extend(s_spans.spans);
+            }
+        }
+
+        if !all_spans.is_empty() {
+            self.ingestor
+                .ingest(all_spans)
+                .await
+                .map_err(|e| Status::from_error(Box::new(e)))?;
+        }
+
+        Ok(Response::new(ExportTraceServiceResponse::default()))
+    }
+}

--- a/src/prometheus/client.rs
+++ b/src/prometheus/client.rs
@@ -1,0 +1,25 @@
+use crate::prometheus::model::NodeMetrics;
+use anyhow::Result;
+use prometheus_parse::Scrape;
+use reqwest::Client;
+
+pub struct MetricsClient {
+    endpoint: &'static str,
+    client: Client,
+}
+
+impl MetricsClient {
+    pub fn new(endpoint: &'static str) -> Self {
+        Self {
+            endpoint,
+            client: Client::new(),
+        }
+    }
+
+    pub async fn get_metrics(&self) -> Result<NodeMetrics> {
+        let response_text = self.client.get(self.endpoint).send().await?.text().await?;
+        let lines = response_text.lines().map(ToString::to_string).map(Ok);
+        let scrape = Scrape::parse(lines)?;
+        scrape.try_into()
+    }
+}

--- a/src/prometheus/mod.rs
+++ b/src/prometheus/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod model;
+pub mod service;

--- a/src/prometheus/model.rs
+++ b/src/prometheus/model.rs
@@ -1,0 +1,99 @@
+use anyhow::{Result, anyhow};
+use prometheus_parse::{Sample, Scrape, Value};
+use std::collections::HashMap;
+
+/// Represents the metrics scraped from the node's Prometheus endpoint.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NodeMetrics {
+    // Block metrics
+    pub block_number: u64,
+    pub density: f64,
+    pub epoch: u64,
+    pub slot_in_epoch: u64,
+    pub slot_num: u64,
+    pub transactions_processed: u64,
+
+    // General process metrics
+    pub cpu_percent_util: f64,
+    pub disk_read_bytes: u64,
+    pub disk_write_bytes: u64,
+    pub disk_total_read_bytes: u64,
+    pub disk_total_write_bytes: u64,
+    pub mem_available_virtual_bytes: u64,
+    pub mem_live_resident_bytes: u64,
+    pub open_files: u64,
+    pub runtime_seconds: u64,
+}
+
+/// A helper struct to simplify accessing metrics from a scrape.
+/// It builds a HashMap for quick lookups by metric name.
+struct MetricParser<'a> {
+    map: HashMap<&'a str, &'a Sample>,
+}
+
+impl<'a> MetricParser<'a> {
+    /// Creates a new MetricParser from a prometheus_parse::Scrape.
+    fn new(scrape: &'a Scrape) -> Self {
+        let map = scrape
+            .samples
+            .iter()
+            .map(|s| (s.metric.as_str(), s))
+            .collect();
+        Self { map }
+    }
+
+    /// Gets a raw Sample by metric name.
+    fn get_sample(&self, name: &str) -> Result<&'a Sample> {
+        self.map
+            .get(name)
+            .copied()
+            .ok_or_else(|| anyhow!("Metric '{}' not found", name))
+    }
+
+    /// Gets a metric value and casts it to u64.
+    fn get_u64(&self, name: &str) -> Result<u64> {
+        let sample = self.get_sample(name)?;
+        match sample.value {
+            Value::Counter(v) | Value::Gauge(v) | Value::Untyped(v) => Ok(v as u64),
+            _ => Err(anyhow!("Metric '{}' has unexpected type for u64", name)),
+        }
+    }
+
+    /// Gets a metric value and casts it to f64.
+    fn get_f64(&self, name: &str) -> Result<f64> {
+        let sample = self.get_sample(name)?;
+        match sample.value {
+            Value::Counter(v) | Value::Gauge(v) | Value::Untyped(v) => Ok(v),
+            _ => Err(anyhow!("Metric '{}' has unexpected type for f64", name)),
+        }
+    }
+}
+
+/// Implementation to convert a Scrape into our NodeMetrics struct.
+impl TryFrom<Scrape> for NodeMetrics {
+    type Error = anyhow::Error;
+
+    fn try_from(scrape: Scrape) -> Result<Self, Self::Error> {
+        let parser = MetricParser::new(&scrape);
+        Ok(Self {
+            // Block
+            block_number: parser.get_u64("cardano_node_metrics_blockNum_int")?,
+            density: parser.get_f64("cardano_node_metrics_density_real")?,
+            epoch: parser.get_u64("cardano_node_metrics_epoch_int")?,
+            slot_in_epoch: parser.get_u64("cardano_node_metrics_slotInEpoch_int")?,
+            slot_num: parser.get_u64("cardano_node_metrics_slotNum_int")?,
+            transactions_processed: parser.get_u64("cardano_node_metrics_txsProcessedNum_int")?,
+
+            // Process
+            cpu_percent_util: parser.get_f64("process_cpu_live")?,
+            disk_read_bytes: parser.get_u64("process_disk_live_read")?,
+            disk_write_bytes: parser.get_u64("process_disk_live_write")?,
+            disk_total_read_bytes: parser.get_u64("process_disk_total_read")?,
+            disk_total_write_bytes: parser.get_u64("process_disk_total_write")?,
+            mem_available_virtual_bytes: parser.get_u64("process_memory_available_virtual")?,
+            mem_live_resident_bytes: parser.get_u64("process_memory_live_resident")?,
+            open_files: parser.get_u64("process_open_files")?,
+            runtime_seconds: parser.get_u64("process_runtime")?,
+        })
+    }
+}

--- a/src/prometheus/service.rs
+++ b/src/prometheus/service.rs
@@ -1,0 +1,53 @@
+use crate::prometheus::{client::MetricsClient, model::NodeMetrics};
+use std::time::Duration;
+use tokio::{
+    sync::mpsc,
+    task::{self, JoinHandle},
+    time,
+};
+use tracing::error;
+
+pub struct MetricsPoller {
+    endpoint: &'static str,
+    interval: Duration,
+}
+
+pub struct MetricsPollerHandle {
+    pub receiver: mpsc::Receiver<NodeMetrics>,
+    pub task_handle: JoinHandle<()>,
+}
+
+impl MetricsPoller {
+    pub fn new(endpoint: &'static str, interval: Duration) -> Self {
+        Self { endpoint, interval }
+    }
+
+    pub fn start(self) -> MetricsPollerHandle {
+        let (sender, receiver) = mpsc::channel(1);
+
+        let task_handle = task::spawn(async move {
+            let client = MetricsClient::new(self.endpoint);
+            let mut tick_timer = time::interval(self.interval);
+
+            loop {
+                tick_timer.tick().await;
+                match client.get_metrics().await {
+                    Ok(metrics) => {
+                        if sender.send(metrics).await.is_err() {
+                            error!("Metrics receiver dropped. Stopping polling task.");
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        error!("Failed to fetch metrics: {:?}", e);
+                    }
+                }
+            }
+        });
+
+        MetricsPollerHandle {
+            receiver,
+            task_handle,
+        }
+    }
+}

--- a/src/states.rs
+++ b/src/states.rs
@@ -28,6 +28,7 @@ pub enum Action {
     Mouse(u16, u16),     // Mouse click at coordinates
     MouseMove(u16, u16), // Mouse movement
     SyncTraceGraph,
+    SyncPromMetrics,
 }
 
 #[derive(Clone, Debug, Default, EnumIter, Display, PartialEq, Eq, Serialize, Deserialize)]
@@ -104,6 +105,7 @@ pub enum InspectOption {
     Ledger,
     Chain,
     Otel,
+    Prometheus,
 }
 
 impl ToLine for InspectOption {

--- a/src/ui/to_rich/metrics.rs
+++ b/src/ui/to_rich/metrics.rs
@@ -1,0 +1,56 @@
+use crate::{
+    prometheus::model::NodeMetrics,
+    ui::{RichText, ToRichText, labeled_default_single},
+};
+
+impl ToRichText for NodeMetrics {
+    fn to_rich_text(&self) -> RichText {
+        let mut lines = Vec::new();
+
+        lines.extend(labeled_default_single("Block Number", self.block_number));
+        lines.extend(labeled_default_single("Density", self.density));
+        lines.extend(labeled_default_single("Epoch", self.epoch));
+        lines.extend(labeled_default_single("Slot in Epoch", self.slot_in_epoch));
+        lines.extend(labeled_default_single("Slot Num", self.slot_num));
+        lines.extend(labeled_default_single(
+            "Transactions Processed",
+            self.transactions_processed,
+        ));
+
+        lines.extend(labeled_default_single(
+            "CPU Percent Util",
+            self.cpu_percent_util,
+        ));
+        lines.extend(labeled_default_single(
+            "Disk Live Read Bytes",
+            self.disk_read_bytes,
+        ));
+        lines.extend(labeled_default_single(
+            "Disk Live Write Bytes",
+            self.disk_write_bytes,
+        ));
+        lines.extend(labeled_default_single(
+            "Disk Total Read Bytes",
+            self.disk_total_read_bytes,
+        ));
+        lines.extend(labeled_default_single(
+            "Disk Total Write Bytes",
+            self.disk_total_write_bytes,
+        ));
+        lines.extend(labeled_default_single(
+            "Mem Available Virtual Bytes",
+            self.mem_available_virtual_bytes,
+        ));
+        lines.extend(labeled_default_single(
+            "Mem Live Resident Bytes",
+            self.mem_live_resident_bytes,
+        ));
+        lines.extend(labeled_default_single("Open Files", self.open_files));
+        lines.extend(labeled_default_single(
+            "Runtime Seconds",
+            self.runtime_seconds,
+        ));
+
+        RichText::Lines(lines)
+    }
+}

--- a/src/ui/to_rich/mod.rs
+++ b/src/ui/to_rich/mod.rs
@@ -5,6 +5,7 @@ pub mod account;
 pub mod block_issuer;
 pub mod drep;
 pub mod header;
+pub mod metrics;
 pub mod nonces;
 pub mod pool;
 pub mod proposal;

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -2,14 +2,15 @@ use crate::{
     app_state::AppState,
     states::Action,
     update::{
-        focus::FocusUpdate, layout::LayoutUpdate, scroll::ScrollUpdate, search::SearchUpdate,
-        select_span::SelectSpanUpdate, tick::TickUpdate, trace_graph::TraceGraphUpdate,
-        window::WindowSizeUpdate,
+        focus::FocusUpdate, layout::LayoutUpdate, prom_metrics::PromMetricsUpdate,
+        scroll::ScrollUpdate, search::SearchUpdate, select_span::SelectSpanUpdate,
+        tick::TickUpdate, trace_graph::TraceGraphUpdate, window::WindowSizeUpdate,
     },
 };
 
 pub mod focus;
 pub mod layout;
+pub mod prom_metrics;
 pub mod scroll;
 pub mod search;
 pub mod select_span;
@@ -31,4 +32,5 @@ pub static UPDATE_DEFS: &[&dyn Update] = &[
     &TickUpdate,
     &TraceGraphUpdate,
     &SelectSpanUpdate,
+    &PromMetricsUpdate,
 ];

--- a/src/update/prom_metrics.rs
+++ b/src/update/prom_metrics.rs
@@ -1,0 +1,13 @@
+use crate::{app_state::AppState, states::Action, update::Update};
+
+/// The Update fn for sync'ing Prometheus metrics.
+pub struct PromMetricsUpdate;
+impl Update for PromMetricsUpdate {
+    fn update(&self, a: &Action, s: &mut AppState) -> Vec<Action> {
+        if *a != Action::SyncPromMetrics {
+            s.prom_metrics.sync();
+        }
+
+        Vec::new()
+    }
+}

--- a/src/update/scroll.rs
+++ b/src/update/scroll.rs
@@ -101,11 +101,13 @@ impl Update for ScrollUpdate {
                     s.otel_view.selected_span = None;
                 }
                 InspectOption::Chain => { /* There's no list widget in the Chain tab */ }
+                InspectOption::Prometheus => { /* There's no list widget in the Prometheus tab */ }
             },
             WidgetSlot::Details => match s.inspect_option.current() {
                 InspectOption::Otel => scroll_trace_details(&mut s.otel_view, direction),
                 InspectOption::Ledger => { /* TODO: Impl item details scroll */ }
                 InspectOption::Chain => {}
+                InspectOption::Prometheus => { /* TODO: Impl metrics scroll */ }
             },
             _ => trace!("No scroll logic for slot {:?}", s.slot_focus),
         }

--- a/src/update/tick.rs
+++ b/src/update/tick.rs
@@ -11,6 +11,6 @@ impl Update for TickUpdate {
         };
         // The list of actions that should happen each tick. We assume that each
         // corresponding Update impls its own 'efficiency' guard.
-        vec![Action::SyncTraceGraph]
+        vec![Action::SyncTraceGraph, Action::SyncPromMetrics]
     }
 }

--- a/src/view/defs.rs
+++ b/src/view/defs.rs
@@ -1,6 +1,7 @@
 use crate::view::block::render_block;
 use crate::view::flame_graph::render_flame_graph;
 use crate::view::nonces::render_nonces;
+use crate::view::prom_metrics::render_prom_metrics;
 use crate::view::span::render_span;
 use crate::view::trace_list::render_traces;
 use crate::{
@@ -65,6 +66,7 @@ impl View for SearchBar {
             InspectOption::Ledger => true,
             InspectOption::Chain => true,
             InspectOption::Otel => false,
+            InspectOption::Prometheus => false,
         }
     }
     fn render(&self, f: &mut Frame, area: Rect, s: &AppState) -> Result<()> {
@@ -81,6 +83,7 @@ impl View for SearchBar {
                 },
                 InspectOption::Chain => &s.chain_view.chain_search.builder,
                 InspectOption::Otel => "",
+                InspectOption::Prometheus => "",
             },
             is_widget_focused(s, self.slot()),
         )
@@ -361,6 +364,26 @@ impl View for SpanDetails {
 
     fn render(&self, frame: &mut Frame, area: Rect, s: &AppState) -> Result<()> {
         render_span(frame, area, &s.otel_view, is_widget_focused(s, self.slot()))
+    }
+}
+
+pub struct PromMetrics;
+impl View for PromMetrics {
+    fn slot(&self) -> WidgetSlot {
+        WidgetSlot::Details
+    }
+
+    fn is_visible(&self, s: &AppState) -> bool {
+        *s.inspect_option.current() == InspectOption::Prometheus
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect, s: &AppState) -> Result<()> {
+        render_prom_metrics(
+            frame,
+            area,
+            &s.prom_metrics,
+            is_widget_focused(s, self.slot()),
+        )
     }
 }
 

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -10,6 +10,7 @@ pub mod flame_graph;
 pub mod header;
 pub mod line;
 pub mod nonces;
+pub mod prom_metrics;
 pub mod search;
 pub mod span;
 pub mod span_bar;
@@ -51,6 +52,7 @@ static VIEW_DEFS: &[&dyn View] = &[
     &FlameGraphDetails,
     &SpanDetails,
     &BottomLine,
+    &PromMetrics,
 ];
 
 pub type SlotViews = HashMap<WidgetSlot, &'static dyn View>;

--- a/src/view/prom_metrics.rs
+++ b/src/view/prom_metrics.rs
@@ -1,0 +1,28 @@
+use crate::{model::prom_metrics::PromMetricsViewState, ui::ToRichText};
+use anyhow::Result;
+use ratatui::{
+    prelude::*,
+    widgets::{Block, Borders, Paragraph},
+};
+
+pub fn render_prom_metrics(
+    frame: &mut Frame,
+    area: Rect,
+    state: &PromMetricsViewState,
+    is_focused: bool,
+) -> Result<()> {
+    let mut block = Block::default().title("Span Details").borders(Borders::ALL);
+    if is_focused {
+        block = block.border_style(Style::default().fg(Color::Blue));
+    }
+
+    let lines = match state.latest_metrics() {
+        Some(metrics) => metrics.to_rich_text().unwrap_lines(),
+        None => vec![Line::from("No metrics.")],
+    };
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds the ability to read prometheus metrics from the otlp collector backend at `localhost:8889/metrics` when bringing up the docker containers in amaru's `monitoring/basic`.